### PR TITLE
Refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(bthief
     src/main.cxx
     src/utils.cxx
     src/crypt.cxx
+    src/browsers/browser.cxx
     src/browsers/chrome/chrome.cxx
     src/browsers/firefox/firefox.cxx
     src/browsers/firefox/library.cxx

--- a/src/browsers/browser.cxx
+++ b/src/browsers/browser.cxx
@@ -1,0 +1,18 @@
+#include "browser.hxx"
+
+std::ostream &operator<<(std::ostream &os, const login &l) {
+    const auto format_time_point = [](const std::chrono::system_clock::time_point &t) {
+        return std::format("{:%F %T %Z}", std::chrono::round<std::chrono::seconds>(t));
+    };
+
+    std::string date_last_used_str = l.date_last_used.time_since_epoch().count() == 0
+                                            ? "never"
+                                            : format_time_point(l.date_last_used);
+
+    return os << "  - " << l.url << "\n"
+              << "    - Username: [" << l.username << "]\n"
+              << "    - Password: [" << l.password << "]\n"
+              << "    - Created: " << format_time_point(l.date_created) << "\n"
+              << "    - Last used: " << date_last_used_str << "\n"
+              << "    - Password last modified: " << format_time_point(l.date_password_modified);
+}

--- a/src/browsers/browser.hxx
+++ b/src/browsers/browser.hxx
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <expected>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -14,6 +15,7 @@ struct login {
     std::chrono::system_clock::time_point date_last_used;
     std::chrono::system_clock::time_point date_password_modified;
 };
+std::ostream &operator<<(std::ostream &, const login &);
 
 /**
  * Error conditions of browser::get_logins().

--- a/src/browsers/browser.hxx
+++ b/src/browsers/browser.hxx
@@ -24,6 +24,7 @@ enum class browser_error {
     bcrypt_error,
     file_not_found,
     json_parse_error,
+    lib_load_error,
     sqlite_error,
 };
 

--- a/src/browsers/chrome/chrome.hxx
+++ b/src/browsers/chrome/chrome.hxx
@@ -22,6 +22,7 @@ private:
     wil::unique_bcrypt_algorithm m_aes_alg;
 
     chrome(std::string, std::filesystem::path, std::filesystem::path);
+    std::string decrypt_password(std::vector<uint8_t> db_password, const BCRYPT_KEY_HANDLE key);
     void kill(void);
 };
 

--- a/src/browsers/firefox/library.hxx
+++ b/src/browsers/firefox/library.hxx
@@ -19,7 +19,7 @@ public:
     explicit library(const std::filesystem::path &);
 
     template<typename T>
-    std::function<T> function(const std::string &name) {
+    std::function<T> get_function(const std::string &name) {
         FARPROC f = GetProcAddress(m_lib.get(), name.c_str());
         if (f == NULL) {
             throw std::runtime_error(std::format("Error loading function '{}' from library '{}'", name, m_path.string()));

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -2,10 +2,7 @@
 #include "browsers/firefox/firefox.hxx"
 #include "utils.hxx"
 #include <array>
-#include <chrono>
-#include <format>
 #include <iostream>
-#include <utility>
 #include <windows.h>
 
 int main() {
@@ -30,7 +27,7 @@ int main() {
         if (!browser) { continue; } // browser not found
 
         auto logins = browser->get_logins();
-        if (!logins.has_value()) {
+        if (!logins) {
             std::cerr << "Error getting logins\n";
             continue;
         }

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -35,21 +35,8 @@ int main() {
             continue;
         }
 
-        const auto format_time_point = [](std::chrono::system_clock::time_point &t) {
-            return std::format("{:%F %T %Z}", std::chrono::round<std::chrono::seconds>(t));
-        };
-
         for (auto &l : logins.value()) {
-            std::string date_last_used_str = l.date_last_used.time_since_epoch().count() == 0
-                                                 ? "never"
-                                                 : format_time_point(l.date_last_used);
-
-            std::cout << "  - " << l.url << "\n"
-                      << "    - Username: [" << l.username << "]\n"
-                      << "    - Password: [" << l.password << "]\n"
-                      << "    - Created: " << format_time_point(l.date_created) << "\n"
-                      << "    - Last used: " << date_last_used_str << "\n"
-                      << "    - Password last modified: " << format_time_point(l.date_password_modified) << "\n";
+            std::cout << l << "\n";
         }
     }
 }


### PR DESCRIPTION
- Overload `operator<<` for login struct
- Chrome: move password decryption out of `get_logins()`
- Firefox: use X macro for loading `nss_library` functions, and handle JSON exceptions